### PR TITLE
Fix link editor resetting saved color and icon selections

### DIFF
--- a/plugins/core/templates/core/links/edit.jinja
+++ b/plugins/core/templates/core/links/edit.jinja
@@ -10,11 +10,15 @@
         <input type="text" name="name" id="core-link-name" placeholder="name..." value="{{ link.name }}" required>
         <label for="core-link-color-name">Color</label>
         <select name="color_name" id="core-link-color-name">
+            {% set selected_color = link.color_name %}
             {% include "/shared/includes/options-color.jinja" %}
         </select>
         <label for="core-link-icon-name">Icon Name</label>
         <select name="icon-name" id="core-link-icon-name">
             <option value="">** No Icon **</option>
+            {% if link.icon_name and link.icon_name not in icon_names %}
+            <option selected value="{{ link.icon_name }}">{{ link.icon_name }} (currently unavailable)</option>
+            {% endif %}
             {% for name in icon_names %}
             <option {% if link.icon_name==name %}selected{% endif %} value="{{ name }}">{{ name }}</option>
             {% endfor %}

--- a/plugins/core/views.py
+++ b/plugins/core/views.py
@@ -269,7 +269,9 @@ async def post_link_edit(link_id: int):
         await flash("link name cannot be blank", "error")
         return redirect(url_for(".get_link_edit", link_id=link_id))
 
-    if icon_name and get_icon_path(icon_name) is None:
+    # Keep a previously selected icon even if its file is temporarily unavailable.
+    # This prevents an unrelated edit from silently clearing the saved icon.
+    if icon_name and icon_name != link.icon_name and get_icon_path(icon_name) is None:
         logger.warning(
             "icon name requested not found, or permission to read is missing::name='%s'",
             icon_name,

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -122,3 +122,23 @@ def test_admin_change_branding(page: Page):
     page.wait_for_url(f"{BASE_URL}/admin/system-settings/")
     page.goto(f"{BASE_URL}")
     expect(page.locator("body header h1")).to_have_text(new_brand_title)
+
+
+def test_edit_link_preserves_color_and_icon(page: Page):
+    page.goto(f"{BASE_URL}/_e2e/login_as_user/admin")
+    page.goto(f"{BASE_URL}/plugins/core/links")
+
+    link_row = page.locator("tbody tr").filter(has_text="Bitwarden")
+    link_row.get_by_title("Edit").click()
+
+    expect(page.locator("#core-link-color-name")).to_have_value("cyan")
+    expect(page.locator("#core-link-icon-name")).to_have_value("bitwarden")
+
+    page.locator("#core-link-name").fill("Bitwarden Vault")
+    page.locator("button[type=submit]").click()
+    page.wait_for_url(f"{BASE_URL}/plugins/core/links")
+
+    edited_row = page.locator("tbody tr").filter(has_text="Bitwarden Vault")
+    edited_row.get_by_title("Edit").click()
+    expect(page.locator("#core-link-color-name")).to_have_value("cyan")
+    expect(page.locator("#core-link-icon-name")).to_have_value("bitwarden")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -135,6 +135,7 @@ def test_edit_link_preserves_color_and_icon(page: Page):
     expect(page.locator("#core-link-icon-name")).to_have_value("bitwarden")
 
     page.locator("#core-link-name").fill("Bitwarden Vault")
+    page.locator("#core-link-url").fill("https://bitwarden.com/")
     page.locator("button[type=submit]").click()
     page.wait_for_url(f"{BASE_URL}/plugins/core/links")
 

--- a/web_portal/templates/shared/includes/options-color.jinja
+++ b/web_portal/templates/shared/includes/options-color.jinja
@@ -1,29 +1,11 @@
-<option value="no-color">** No Color **</option>
+<option value="no-color" {% if selected_color|default("no-color") == "no-color" %}selected{% endif %}>** No Color **</option>
 <optgroup label="Standard">
-    <option>white</option>
-    <option>grey</option>
-    <option>grey-black</option>
-    <option>black</option>
-    <option>red</option>
-    <option>orange</option>
-    <option>yellow</option>
-    <option>green</option>
-    <option>green-blue</option>
-    <option>cyan</option>
-    <option>blue</option>
-    <option>purple</option>
-    <option>pink</option>
-    <option>pink-red</option>
+    {% for color in ("white", "grey", "grey-black", "black", "red", "orange", "yellow", "green", "green-blue", "cyan", "blue", "purple", "pink", "pink-red") %}
+    <option value="{{ color }}" {% if selected_color|default("no-color") == color %}selected{% endif %}>{{ color }}</option>
+    {% endfor %}
 </optgroup>
 <optgroup label="Alternatives">
-    <option>red-alt</option>
-    <option>orange-alt</option>
-    <option>yellow-alt</option>
-    <option>green-alt</option>
-    <option>green-blue-alt</option>
-    <option>cyan-alt</option>
-    <option>blue-alt</option>
-    <option>purple-alt</option>
-    <option>pink-alt</option>
-    <option>pink-red-alt</option>
+    {% for color in ("red-alt", "orange-alt", "yellow-alt", "green-alt", "green-blue-alt", "cyan-alt", "blue-alt", "purple-alt", "pink-alt", "pink-red-alt") %}
+    <option value="{{ color }}" {% if selected_color|default("no-color") == color %}selected{% endif %}>{{ color }}</option>
+    {% endfor %}
 </optgroup>


### PR DESCRIPTION
## Summary

- Preserve the saved color when editing an existing saved link.
- Preserve the icon selection if its icon file is temporarily unavailable.

## Problems

The link edit form did not mark the saved color as selected. So, reopening a link and saving an unrelated change reset the color to “No Color.”

The icon selector could also clear a saved icon when that icon was not among the currently discovered icons.

## Testing

- Project formatting and lint checks are working.
- All existing unit tests pass.
- Added end-to-end coverage that edits a link and verifies its color and icon remain selected after saving.